### PR TITLE
Fixes bug when supplied a non numeric ID string

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,10 +1,11 @@
-(defproject co.datil/personas "1.0.1"
+(defproject co.datil/personas "1.0.2"
   :description "Librería para validación de números de identificación de personas y compañías"
   :url "https://developers.datil.co"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.10.1"]
                  [org.clojure/clojurescript "1.10.516" :scope "provided"]]
+  :deploy-repositories {"releases" {:url "https://repo.clojars.org" :creds :gpg}}
   :plugins [[lein-cljsbuild "1.1.7"]]
   :clean-targets ^{:protect false}
   [:target-path

--- a/test/personas/id/ec_test.cljc
+++ b/test/personas/id/ec_test.cljc
@@ -92,3 +92,9 @@
                          :country "EC"
                          :type id-ec/tax-id-code})
          true)))
+
+(deftest invalid-not-numeric-id
+  (is (= (sut/valid-id? {:identification "09623786OO001"
+                         :country "EC"
+                         :type id-ec/tax-id-code})
+         false)))


### PR DESCRIPTION
The function `numeric?` was added to check if the supplier identification number is a number string.